### PR TITLE
Added task to add aliases

### DIFF
--- a/local.yml
+++ b/local.yml
@@ -19,3 +19,4 @@
     - include_tasks: tasks/logrotate.yml
     - include_tasks: tasks/packages.yml
     - include_tasks: tasks/cron.yml
+    - include_tasks: tasks/alias.yml

--- a/tasks/alias.yml
+++ b/tasks/alias.yml
@@ -19,4 +19,4 @@
     line: "[ -f ~/.bash_aliases ] && . ~/.bash_aliases"
     create: yes
     mode: '0644'
-    insertafter: EOF´
+    insertafter: EOF

--- a/tasks/alias.yml
+++ b/tasks/alias.yml
@@ -1,0 +1,22 @@
+- name: Ensure .bash_aliases file with common aliases
+  blockinfile:
+    path: "/home/scanreach/.bash_aliases"
+    create: yes
+    mode: '0644'
+    block: |
+      # Custom aliases
+      alias ll='ls -lah'
+      alias gs='git status'
+      alias ..='cd ..'
+      alias update='sudo apt update && sudo apt upgrade -y'
+      alias redis='sudo docker exec -it redis redis-cli'
+      alias database='sudo docker exec -it postgres  psql -U postgres -d inrange-onprem'
+  become_user: "scanreach"
+
+- name: Ensure .bashrc sources .bash_aliases
+  lineinfile:
+    path: "/home/scanreach/.bashrc"
+    line: "[ -f ~/.bash_aliases ] && . ~/.bash_aliases"
+    create: yes
+    mode: '0644'
+    insertafter: EOF´


### PR DESCRIPTION
This pull request introduces a new task for managing shell aliases and ensures that these aliases are correctly sourced in the user's shell configuration. The changes improve the developer experience by adding commonly used command shortcuts.

Please let me know, or add, further aliases if needed. 

### Additions to task management:

* [`local.yml`](diffhunk://#diff-342bbbd527cd4be2219251b786ad5d16636b4757e6e6c66bf0dc12dc854c0c13R22): Added a new task, `tasks/alias.yml`, to the list of included tasks.
* [`tasks/alias.yml`](diffhunk://#diff-e31df48b2721e8753b9b2f08c96d6e9e6ee81335cd2cbb75500fcf213c87c9faR1-R22): Created a new task to manage a `.bash_aliases` file with predefined aliases (e.g., `ll`, `gs`, `update`, etc.) and ensure it is sourced in the `.bashrc` file. This task also sets appropriate permissions and ensures the aliases are loaded for the `scanreach` user.